### PR TITLE
Set correct Content-Type for patch request

### DIFF
--- a/js/jquery.tus.js
+++ b/js/jquery.tus.js
@@ -157,7 +157,8 @@
         return xhr;
       },
       headers: {
-        'Offset': range_from
+        'Offset': range_from,
+        'Content-Type': 'application/offset+octet-stream'
       }
     };
 


### PR DESCRIPTION
According to the documentation, all PATCH request must use `Content-Type: application/offset+octet-stream`.
