### PR TITLE
allow tus client to support https

### DIFF
--- a/js/jquery.tus.js
+++ b/js/jquery.tus.js
@@ -109,6 +109,11 @@
       })
       .done(function(data, textStatus, jqXHR) {
         var location = jqXHR.getResponseHeader('Location');
+
+        if (self.options.endpoint.indexOf("https") == 0) {
+          location = location.replace('http', 'https');
+        }
+
         if (!location) {
           return self._emitFail('Could not get url for file resource. ' + textStatus);
         }


### PR DESCRIPTION
this patch will allow tus client work over https protocol. otherwise in Firefox it will throw “Blocked loading mixed active content” exception.

Note that i setup tus server after nginx proxy to allow server work over https.
